### PR TITLE
Fixes pseudo likelihood cache

### DIFF
--- a/flymc/models.py
+++ b/flymc/models.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.random as npr
+import pylru
 from abc import ABCMeta
 from abc import abstractmethod
 
@@ -9,45 +10,6 @@ def log_logistic(x):
     # Overflow-avoiding version of the log logistic function.
     abs_x = np.abs(x)
     return 0.5 * (x - abs_x) - np.log(1+np.exp(-abs_x))
-
-class CacheWithIdxs(object):
-    def __init__(self, N, N_theta):
-        self.size = N_theta
-        self.values = np.zeros((N, N_theta))
-        self.exists = np.zeros((N, N_theta), dtype=bool)
-        self.lists  = [] # A list of lists containing the cached indices
-        for i in range(N_theta): self.lists.append([])
-        self.thetas = [None]*N_theta
-        self.oldest = 0
-
-    def retrieve(self, th, idxs):
-        # Check whether it's in the cache and give the values if it is
-        # NOTE: cache tests identity, not equality, so if the value of a
-        # th object changes it will be messed up
-        for i, th_cache in enumerate(self.thetas):
-            if th_cache is not None and np.all(th == th_cache) and np.all(self.exists[idxs, i]):
-                self.oldest = (i + 1) % len(self.thetas)
-                return self.values[idxs, i]
-
-    def store(self, th, idxs, new_values):
-        for i, th_cache in enumerate(self.thetas):
-            if th_cache is not None and th is th_cache:
-                assert(np.all(th == th_cache)), "Value of th changed" # This can be turned off for performance
-                vacant = np.where(np.logical_not(self.exists[idxs, i]))
-                self.values[idxs[vacant], i] = new_values[vacant]
-                self.exists[idxs[vacant], i] = 1
-                self.lists[i] += list(idxs[vacant])
-                return
-
-        # if we didn't find it, we have a new theta
-        i = self.oldest
-        self.oldest = (self.oldest + 1) % len(self.thetas)
-        self.thetas[i] = th.copy()
-        self.exists[self.lists[i], i] = 0
-        self.exists[idxs, i] = 1
-        self.values[idxs, i] = new_values
-        del self.lists[i][:]
-        self.lists[i] += list(idxs)
 
 class SimpleCache(object):
     def __init__(self, N_theta):
@@ -62,7 +24,7 @@ class SimpleCache(object):
         # th object changes it will be messed up
         for i, th_cache in enumerate(self.thetas):
             if th_cache is not None and th is th_cache:
-                assert(np.all(th == th_cache)), "Value of th changed" 
+                assert(np.all(th == th_cache)), "Value of th changed"
                 self.oldest = (i + 1) % len(self.thetas)
                 return self.values[i]
 
@@ -79,9 +41,10 @@ class Model(object):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, cache_size=2):
+    def __init__(self, cache_size=1000000):
+        # TODO: cache_size should default to 2N where N is numbe of data poins
         # To make things cache-friendly, should always evaluate the old value first
-        self.pseudo_lik_cache = CacheWithIdxs(self.N, cache_size)
+        self.pseudo_lik_cache = pylru.lrucache(cache_size)
         self.p_marg_cache = SimpleCache(cache_size)
         self.num_lik_evals = 0
         self.num_D_lik_evals = 0
@@ -97,20 +60,24 @@ class Model(object):
                   + np.sum(self._D_log_pseudo_lik(th, z.bright), axis=0)
 
     def log_pseudo_lik(self, th, idxs):
-        # Pseduo-likelihood: ratio of bright to dark 
-        # proabilities of indices idxs at th
-        # Check for cached value:
-        cached_value = self.pseudo_lik_cache.retrieve(th, idxs)
-        if cached_value is not None:
-            # this is only to test the cache. Comment out for real use
-            # assert np.all(cached_value == self._LBgap(th,idxs) + np.log(1-np.exp(-self._LBgap(th,idxs))) )
-            return cached_value
+        th_str = str(th) # convert to string so hashable
 
-        # Otherwise compute it:
-        gap = self._LBgap(th,idxs)
-        result = gap + np.log(1-np.exp(-gap)) # this way avoids overflow
-        self.pseudo_lik_cache.store(th, idxs, result)
-        self.num_lik_evals += len(idxs)
+        # compute pseudo likelihood at uncached points
+        idxs_miss = [idx for idx in idxs if (th_str, idx) not in self.pseudo_lik_cache]
+        gap_miss = self._LBgap(th, idxs_miss)
+        result_miss = gap_miss + np.log(1-np.exp(-gap_miss)) # this way avoids overflow
+        self.num_lik_evals += len(idxs_miss)
+
+        result = np.zeros(idxs.shape)
+        miss_ptr = 0
+        for i, idx in enumerate(idxs):
+            if miss_ptr < len(idxs_miss) and idx == idxs_miss[miss_ptr]:
+                res = result_miss[miss_ptr]
+                miss_ptr += 1
+                self.pseudo_lik_cache[(th_str, idx)] = res
+                result[i] = res
+            else:
+                result[i] = self.pseudo_lik_cache[(th_str, idx)]
         return result
 
     def _D_log_pseudo_lik(self, th, idxs):
@@ -119,14 +86,14 @@ class Model(object):
         D_LBgap = self._D_LBgap(th, idxs)
         self.num_D_lik_evals += len(idxs)
         return D_LBgap/(1-np.exp(-gap)).reshape((len(idxs),) + (1,)*th.ndim)
-    
+
     def log_p_marg(self, th, z=None):
         # marginal posterior prob. Takes z as an optional agrument but doesn't use it
         cached_value = self.p_marg_cache.retrieve(th)
         if cached_value != None:
             # this is only to test the cache. Comment out for real use
             # assert cached_value == self._logPrior(th) + np.sum(self._logL(th, range(self.N)))
-            return cached_value                        
+            return cached_value
 
         result = self._logPrior(th) + np.sum(self._logL(th, range(self.N)))
         self.p_marg_cache.store(th, result)
@@ -142,7 +109,7 @@ class Model(object):
 
     def reset(self):
         # resets the counters and cache for a fresh start
-        self.pseudo_lik_cache = CacheWithIdxs(self.N, self.pseudo_lik_cache.size)
+        self.pseudo_lik_cache = pylru.lrucache(self.pseudo_lik_cache.size())
         self.p_marg_cache = SimpleCache(self.p_marg_cache.size)
         self.num_lik_evals = 0
         self.num_D_lik_evals = 0
@@ -239,7 +206,7 @@ class LogisticModel(Model):
         y = np.dot(self.dat[idxs,:],th[:,None])[:,0]
         L = log_logistic(y)
         a, b, c = self.coeffs
-        B = a[idxs]*y**2 + b[idxs]*y + c[idxs] 
+        B = a[idxs]*y**2 + b[idxs]*y + c[idxs]
         return L - B
 
     def _D_logB(self, th, idxs):
@@ -259,13 +226,13 @@ class LogisticModel(Model):
         y  = np.dot(th, self.dat_sum)
         y2 = np.dot(th[None,:],np.dot(self.dat_prod,th[:,None]))
         return y2 + y # note: we're ignoring a constant here since we don't care about normalization
-  
+
     def _D_logBProduct(self, th):
         return self.dat_sum + 2*np.dot(self.dat_prod,th[:,None])[:,0]
 
     def _logPrior(self, th):
         return -0.5*np.sum((th/self.th0)**2)
- 
+
     def _D_logPrior(self, th):
         return -th/self.th0**2
 
@@ -274,7 +241,7 @@ class LogisticModel(Model):
 
     def _logistic_bound(self, y0):
         # Coefficients of a quadratic lower bound to the log-logistic function
-        # i.e    a*x**2 + b*x + c < log(  exp(x)/(1+exp(x))  ) 
+        # i.e    a*x**2 + b*x + c < log(  exp(x)/(1+exp(x))  )
         # y0 parameterizes a family of lower bounds to the logistic function
         # (the bound is tight at +/- y0)
         pexp = np.exp(y0)
@@ -363,14 +330,14 @@ class MulticlassLogisticModel(Model):
             /np.sum(exp_y, axis=1)[ : ,None,None]  )
             # size is:      (len(idxs), K  , D  )
 
-    def _D_logB(self, th, idxs):        
+    def _D_logB(self, th, idxs):
         th_sumk = np.sum(th, axis=0)
         A_th = 0.25*(-th + th_sumk[None,:]/self.K) # size (K, D)
         return             self.x[idxs,:][ : ,None, :  ]   \
                    * ( self.t_hot[idxs,:][ : , :  ,None]   \
                        +   self.b[idxs,:][ : , :  ,None]   \
          + 2 * self.x[idxs,:].dot(A_th.T)[ : , :  ,None] )
-          # size is:               (len(idxs), K  , D  )                
+          # size is:               (len(idxs), K  , D  )
 
     def _D_LBgap(self, th, idxs):
 
@@ -379,10 +346,10 @@ class MulticlassLogisticModel(Model):
         A_th = 0.25*(-th + th_sumk[None,:]/self.K) # size (K, D)
         return             self.x[idxs,:][ : ,None, :  ]   \
                             *(    - exp_y[ : , :  ,None]  \
-                   /np.sum(exp_y, axis=1)[ : ,None,None]  
+                   /np.sum(exp_y, axis=1)[ : ,None,None]
                        -   self.b[idxs,:][ : , :  ,None]   \
          - 2 * self.x[idxs,:].dot(A_th.T)[ : , :  ,None] )
-          # size is:               (len(idxs), K  , D  )                
+          # size is:               (len(idxs), K  , D  )
 
     def _logBProduct(self, th):
         th_sumk = np.sum(th, axis=0)
@@ -398,7 +365,7 @@ class MulticlassLogisticModel(Model):
         return    self.xt_sum                   \
                 + 2 * np.dot(A_th, self.xx_sum) \
                 + self.xb_sum
-        
+
     def _logPrior(self, th):
         return -0.5*np.sum(th**2)/self.th0**2
 
@@ -442,7 +409,7 @@ class RobustRegressionModel(Model):
         self.v     = v     = float(v)
         self.y0    = y0    = float(y0)
         t = t_raw / scale
-        self.logZ = - np.log(scale) # normalization to account for change in scale 
+        self.logZ = - np.log(scale) # normalization to account for change in scale
 
         self.x = x
         self.t = t
@@ -472,7 +439,7 @@ class RobustRegressionModel(Model):
         y_pred = np.dot(self.x[idxs,:],th[:,None])[:,0]
         residuals = self.t[idxs] - y_pred
         return -self.x[idxs, :] \
-            * (- residuals*(v+1)/(v + residuals**2) )[:,None] 
+            * (- residuals*(v+1)/(v + residuals**2) )[:,None]
 
     def _logB(self, th, idxs):
         # lower bound on logistic regression log likelihoods
@@ -481,13 +448,13 @@ class RobustRegressionModel(Model):
         residuals = self.t[idxs] - y_pred
         a, c = self.coeffs
         return a[idxs]*residuals**2 + c[idxs] + self.logZ
-        
+
     def _D_logB(self, th, idxs):
         y_pred = np.dot(self.x[idxs,:],th[:,None])[:,0]
         residuals = self.t[idxs] - y_pred
         a, _ = self.coeffs
         return -self.x[idxs,:]*(2*a[idxs]*residuals)[:,None]
-        
+
     def _LBgap(self, th, idxs):
         # sum of derivative of log likelihoods of data points idxs
         y_pred = np.dot(self.x[idxs,:],th[:,None])[:,0]
@@ -504,7 +471,7 @@ class RobustRegressionModel(Model):
         a, _ = self.coeffs
         return -self.x[idxs, :] \
             * ( - residuals*(v+1)/(v + residuals**2)\
-                - residuals*a[idxs]*2              )[:,None] 
+                - residuals*a[idxs]*2              )[:,None]
 
     def _logBProduct(self, th):
         # log of the product of all the lower bounds
@@ -516,7 +483,7 @@ class RobustRegressionModel(Model):
     def _logPrior(self, th):
         # sparse prior
         return - np.sum(np.abs(th))/self.th0
- 
+
     def _D_logPrior(self, th):
         return -np.sign(th)/self.th0
 

--- a/flymc/step_algorithms.py
+++ b/flymc/step_algorithms.py
@@ -4,7 +4,7 @@ from abc import ABCMeta
 from abc import abstractmethod
 
 class Stepper(object):
-    
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -23,7 +23,7 @@ class ThetaStepMH(Stepper):
     def step(self, th, z):
         th_new = th + npr.standard_normal(th.shape)*self.stepsize
         # Cache friendly order: evaluate old value first
-        if np.log(npr.rand()) < - self.prob(th, z) + self.prob(th_new, z) :
+        if np.log(npr.rand()) < - self.prob(th, z) + self.prob(th_new, z):
             self.num_rejects = 0
             return th_new
         else:
@@ -80,7 +80,7 @@ class ThetaStepSlice(Stepper):
             if new_logprob > curr_logprob:
                 break # we have our sample
             elif x < 0:
-                L = x 
+                L = x
             elif x > 0:
                 R = x
             else:


### PR DESCRIPTION
This patch addresses incorrect caching of pseudo-likelihoods for `LogisticModel`. The provided `CacheWithIdx` currently performs caching on both arguments `th` (the parameter values) and `idxs` (the indices of the bright data points). This currently does not handle cases where `idxs2` may be a subset or share data points with `idxs`.

For example, if `idxs2` is a subset of `idxs` then (`th`, `idxs`) and (`th`, `idxs2`) are treated as two separate cache misses even though `idxs2` just returns a subset of the pseudo-likelihoods already computed and cached for `idxs`.

In our patch, `pylru` is used as an element-wise cache on (`th`, `idx`) where `idx` is a single index rather than an array of indices. This allows sharing of cached elements between likelihood evaluations used for computing MH acceptance probabilities (i.e. the (t+1)st iteration's numerator term P(\theta_{t} | z^{t+1}_{i}) and the previous iteration's denominator term P(\theta_{t} | z^{t}_i) can share indices i where z^{t+1}_{i} = 1 = z^{t}_i).

@xukai92 @blutooth
